### PR TITLE
[FEAT/#45] 워치 데이터 전송, 암호화 관련 유틸 코드 추가

### DIFF
--- a/app/src/main/java/com/ddanddan/ddanddan/ext/ContextExt.kt
+++ b/app/src/main/java/com/ddanddan/ddanddan/ext/ContextExt.kt
@@ -1,0 +1,15 @@
+package com.ddanddan.ddanddan.ext
+
+import android.content.Context
+import android.widget.Toast
+import com.ddanddan.ddanddan.BuildConfig
+
+/**
+ * 디버그 모드에서만 Toast
+ */
+fun Context.showDebugToast(message: String) {
+    if (BuildConfig.DEBUG) {
+        Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
+    }
+}
+

--- a/app/src/main/java/com/ddanddan/ddanddan/util/SecurityUtils.kt
+++ b/app/src/main/java/com/ddanddan/ddanddan/util/SecurityUtils.kt
@@ -1,0 +1,36 @@
+package com.ddanddan.ddanddan.util
+
+import android.content.Context
+import android.util.Base64
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKeys
+import com.ddanddan.ddanddan.BuildConfig
+import timber.log.Timber
+import java.security.KeyFactory
+import java.security.PublicKey
+import java.security.spec.X509EncodedKeySpec
+import javax.crypto.Cipher
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.SecretKeySpec
+
+object SecurityUtils {
+
+    /**
+     * AES를 사용해 문자열을 암호화하는 함수
+     */
+    fun encrypt(data: String): String? {
+        return try {
+            val aesKey = BuildConfig.AES_KEY
+            val secretKeySpec = SecretKeySpec(Base64.decode(aesKey, Base64.DEFAULT), "AES")
+            val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+            cipher.init(Cipher.ENCRYPT_MODE, secretKeySpec)
+            val iv = cipher.iv
+            val encryptedBytes = cipher.doFinal(data.toByteArray(Charsets.UTF_8))
+            val combined = iv + encryptedBytes
+            Base64.encodeToString(combined, Base64.DEFAULT)
+        } catch (e: Exception) {
+            Timber.e(e, "암호화에 실패했습니다.")
+            null
+        }
+    }
+}

--- a/app/src/main/java/com/ddanddan/ddanddan/util/SecurityUtils.kt
+++ b/app/src/main/java/com/ddanddan/ddanddan/util/SecurityUtils.kt
@@ -1,16 +1,9 @@
 package com.ddanddan.ddanddan.util
 
-import android.content.Context
 import android.util.Base64
-import androidx.security.crypto.EncryptedSharedPreferences
-import androidx.security.crypto.MasterKeys
 import com.ddanddan.ddanddan.BuildConfig
 import timber.log.Timber
-import java.security.KeyFactory
-import java.security.PublicKey
-import java.security.spec.X509EncodedKeySpec
 import javax.crypto.Cipher
-import javax.crypto.spec.GCMParameterSpec
 import javax.crypto.spec.SecretKeySpec
 
 object SecurityUtils {

--- a/app/src/main/java/com/ddanddan/ddanddan/util/WatchUtils.kt
+++ b/app/src/main/java/com/ddanddan/ddanddan/util/WatchUtils.kt
@@ -1,0 +1,66 @@
+package com.ddanddan.ddanddan.util
+
+import android.content.Context
+import com.ddanddan.ddanddan.R
+import com.ddanddan.ddanddan.ext.showDebugToast
+import com.google.android.gms.wearable.Node
+import com.google.android.gms.wearable.PutDataMapRequest
+import com.google.android.gms.wearable.Wearable
+import timber.log.Timber
+
+/**
+ * 전제 조건
+ * 1. 워치와 스마트폰이 연결되어있어야 함
+ * 2. data를 보내는 스마트폰 앱의 applicationId와 수신하는 워치 쪽 applicationId가 일치해야 함
+ */
+object WatchBridge {
+
+    /**
+     * 워치 연결 상태를 확인하는 함수
+     */
+    fun checkWatchConnection(
+        context: Context,
+        onConnected: (List<Node>) -> Unit,
+        onNotConnected: () -> Unit
+    ) = context.run {
+        Wearable.getNodeClient(this).connectedNodes
+            .addOnSuccessListener { nodes ->
+                if (nodes.isEmpty()) {
+                    // 연결된 워치가 없을 경우 콜백 호출
+                    onNotConnected()
+                    showDebugToast(getString(R.string.no_watch_connected))
+                } else {
+                    // 연결된 워치가 있을 경우 연결된 노드 리스트를 콜백으로 전달
+                    onConnected(nodes)
+                    Timber.d("Connected Watches: ${nodes.map { it.displayName }}")
+                }
+            }
+            .addOnFailureListener { e ->
+                showDebugToast(getString(R.string.watch_connection_check_failed, e.message))
+                Timber.e("Watch connection check failed: ${e.message}")
+            }
+    }
+
+    /**
+     * 워치로 액세스 토큰을 전송하는 함수
+     */
+    fun sendAccessTokenToWatch(context: Context, accessToken: String, node: Node) = context.run {
+        val dataClient = Wearable.getDataClient(this)
+
+        val putDataReq = PutDataMapRequest.create("/access_token").run {
+            dataMap.putString("accessToken", accessToken)
+            dataMap.putLong("timeStamp", System.currentTimeMillis())
+            asPutDataRequest()
+        }
+
+        dataClient.putDataItem(putDataReq)
+            .addOnSuccessListener {
+                showDebugToast(getString(R.string.watch_send_token_success))
+                Timber.d(getString(R.string.watch_send_token_success))
+            }
+            .addOnFailureListener { e ->
+                showDebugToast(getString(R.string.watch_send_token_failure, e.message))
+                Timber.e(getString(R.string.watch_send_token_failure, e.message))
+            }
+    }
+}

--- a/app/src/main/java/com/ddanddan/ddanddan/util/WatchUtils.kt
+++ b/app/src/main/java/com/ddanddan/ddanddan/util/WatchUtils.kt
@@ -42,25 +42,30 @@ object WatchUtils {
     }
 
     /**
-     * 워치로 액세스 토큰을 전송하는 함수
+     * 워치로 암호화된 액세스 토큰을 전송하는 함수
      */
-    fun sendAccessTokenToWatch(context: Context, accessToken: String, node: Node) = context.run {
+    fun sendAccessTokenToWatch(context: Context, accessToken: String) = context.run {
         val dataClient = Wearable.getDataClient(this)
+        val encryptedToken = SecurityUtils.encrypt(accessToken)
 
-        val putDataReq = PutDataMapRequest.create("/access_token").run {
-            dataMap.putString("accessToken", accessToken)
-            dataMap.putLong("timeStamp", System.currentTimeMillis())
-            asPutDataRequest()
+        if (encryptedToken.isNullOrEmpty()) {
+            val putDataReq = PutDataMapRequest.create("/access_token").run {
+                dataMap.putString("accessToken", encryptedToken!!)
+                dataMap.putLong("timeStamp", System.currentTimeMillis())
+                asPutDataRequest()
+            }
+
+            dataClient.putDataItem(putDataReq)
+                .addOnSuccessListener {
+                    showDebugToast(getString(R.string.watch_send_token_success))
+                    Timber.d(getString(R.string.watch_send_token_success))
+                }
+                .addOnFailureListener { e ->
+                    showDebugToast(getString(R.string.watch_send_token_failure, e.message))
+                    Timber.e(getString(R.string.watch_send_token_failure, e.message))
+                }
+        } else {
+            Timber.e(getString(R.string.token_encrypt_failure))
         }
-
-        dataClient.putDataItem(putDataReq)
-            .addOnSuccessListener {
-                showDebugToast(getString(R.string.watch_send_token_success))
-                Timber.d(getString(R.string.watch_send_token_success))
-            }
-            .addOnFailureListener { e ->
-                showDebugToast(getString(R.string.watch_send_token_failure, e.message))
-                Timber.e(getString(R.string.watch_send_token_failure, e.message))
-            }
     }
 }

--- a/app/src/main/java/com/ddanddan/ddanddan/util/WatchUtils.kt
+++ b/app/src/main/java/com/ddanddan/ddanddan/util/WatchUtils.kt
@@ -13,7 +13,7 @@ import timber.log.Timber
  * 1. 워치와 스마트폰이 연결되어있어야 함
  * 2. data를 보내는 스마트폰 앱의 applicationId와 수신하는 워치 쪽 applicationId가 일치해야 함
  */
-object WatchBridge {
+object WatchUtils {
 
     /**
      * 워치 연결 상태를 확인하는 함수

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,4 +5,9 @@
     <string name="onboarding_tv_access_location_subtitle">지역 기반 기능 사용 시 위치 권한이 필요합니다.</string>
     <string name="onboarding_tv_access_location_allow">허용</string>
     <string name="onboarding_tv_access_location_decline">허용 안함</string>
+    <string name="watch_send_token_success">워치로 토큰 전송 성공</string>
+    <string name="watch_send_token_failure">워치로 토큰 전송 실패: %1$s</string>
+    <string name="token_encrypt_failure">토큰 암호화에 실패했습니다.</string>
+    <string name="no_watch_connected">워치가 연결되어 있지 않습니다.</string>
+    <string name="watch_connection_check_failed">워치 상태 확인 실패: %1$s</string>
 </resources>

--- a/build-logic/convention/src/main/java/com/ddanddan/convention/src/main/kotlin/plugins/AndroidApplicationPlugin.kt
+++ b/build-logic/convention/src/main/java/com/ddanddan/convention/src/main/kotlin/plugins/AndroidApplicationPlugin.kt
@@ -43,9 +43,9 @@ class AndroidApplicationPlugin : Plugin<Project> {
                 configureAndroidCommonPlugin()
                 configureDefault()
 
-               packagingOptions {
+                packagingOptions {
                     exclude("META-INF/DEPENDENCIES")
-                   exclude("migrateToAndroidx/migration.xml")
+                    exclude("migrateToAndroidx/migration.xml")
                 }
 
                 buildFeatures {
@@ -62,11 +62,7 @@ class AndroidApplicationPlugin : Plugin<Project> {
                             "BASE_URL",
                             gradleLocalProperties(rootDir).getProperty("base.url"),
                         )
-//                        buildConfigField(
-//                            "String",
-//                            "KAKAO_REDIRECT_URL",
-//                            gradleLocalProperties(rootDir).getProperty("kakao.redirect"),
-//                        )
+
                         buildConfigField(
                             "String",
                             "KAKAO_APP_KEY",
@@ -75,6 +71,12 @@ class AndroidApplicationPlugin : Plugin<Project> {
 
                         manifestPlaceholders["KAKAO_APP_KEY"] =
                             gradleLocalProperties(rootDir).getProperty("kakaoAppKey")
+
+                        buildConfigField(
+                            "String",
+                            "AES_KEY",
+                            gradleLocalProperties(rootDir).getProperty("AES_KEY"),
+                        )
                     }
 
                     release {
@@ -83,15 +85,17 @@ class AndroidApplicationPlugin : Plugin<Project> {
                             "BASE_URL",
                             gradleLocalProperties(rootDir).getProperty("base.url"),
                         )
-//                        buildConfigField(
-//                            "String",
-//                            "KAKAO_REDIRECT_URL",
-//                            gradleLocalProperties(rootDir).getProperty("kakao.redirect"),
-//                        )
+
                         buildConfigField(
                             "String",
                             "KAKAO_APP_KEY",
                             gradleLocalProperties(rootDir).getProperty("kakao.key"),
+                        )
+
+                        buildConfigField(
+                            "String",
+                            "AES_KEY",
+                            gradleLocalProperties(rootDir).getProperty("AES_KEY"),
                         )
 
                         manifestPlaceholders["KAKAO_APP_KEY"] =
@@ -166,6 +170,8 @@ class AndroidApplicationPlugin : Plugin<Project> {
                 implementation(libs.getBundle("appModuleLibraryEtc"))
 
                 implementation(libs.getLibrary("play-services-location"))
+
+                implementation(libs.getLibrary("play-services-wearable"))
             }
         }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -84,6 +84,7 @@ leakCanaryVersion = "2.11"
 jvmVersion = "17"
 activityVersion = "1.9.0"
 activity = "1.9.2"
+playServicesWearableVersion = "18.2.0"
 
 [libraries]
 # gradle
@@ -204,6 +205,9 @@ espresso = { group = "androidx.test.espresso", name = "espresso-core", version.r
 androidx-ui-text-android = { group = "androidx.compose.ui", name = "ui-text-android", version ="uiPreviewCompose" }
 ui-tooling-compose = {group = "androidx.compose.ui", name="ui-tooling", version.ref="uiPreviewCompose"}
 activity = { group = "androidx.activity", name = "activity", version.ref = "activity" }
+
+## Watch
+play-services-wearable = { group = "com.google.android.gms", name = "play-services-wearable", version.ref = "playServicesWearableVersion" }
 
 # 사용될 플러그인
 [plugins]


### PR DESCRIPTION
### 암호화/복호화 전략
local.properties에 key를 추가하고 대칭키 방식으로 암호화/복호화 

### 워치로 암호화된 accessToken 보내는 로직
```
                WatchUtils.checkWatchConnection(
                    context = this@SignInActivity,
                    onConnected = { nodes ->
                        for (node in nodes) {
                            WatchUtils.sendAccessTokenToWatch(this@SignInActivity, "123123123", node)
                        }
                    },
                    onNotConnected = {
                        Toast.makeText(this@SignInActivity, getString(R.string.no_watch_connected), Toast.LENGTH_SHORT).show()
                    }
                )
```