### PR TITLE
[FEAT/#173] 친구 추가 팝업 예외 처리

### DIFF
--- a/app/src/main/java/com/ddanddan/ddanddan/presentation/MainActivity.kt
+++ b/app/src/main/java/com/ddanddan/ddanddan/presentation/MainActivity.kt
@@ -40,7 +40,8 @@ class MainActivity : ComponentActivity() {
                                 )
                             )
                         },
-                        inviteCode = inviteCode
+                        inviteCode = inviteCode,
+                        onInviteCodeConsumed = { inviteCode = null }
                     )
                 }
             }

--- a/app/src/main/java/com/ddanddan/ddanddan/presentation/MainActivity.kt
+++ b/app/src/main/java/com/ddanddan/ddanddan/presentation/MainActivity.kt
@@ -21,10 +21,11 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
 
+    private var inviteCode by mutableStateOf<String?>(null)
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            var inviteCode by remember { mutableStateOf<String?>(null) }
             DDanDDanTheme {
                 Surface(
                     modifier = Modifier.fillMaxSize(),
@@ -43,15 +44,24 @@ class MainActivity : ComponentActivity() {
                     )
                 }
             }
+            handleInviteLink(intent)
+        }
+    }
 
-            ChottuLink.getAppLinkData(intent).addOnSuccessListener { result ->
-                result?.link?.let { link ->
-                    val code = link.getQueryParameter("code")
-                    if (!code.isNullOrEmpty()) {
-                        inviteCode = code
-                    }
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        handleInviteLink(intent)
+    }
+
+    private fun handleInviteLink(intent: Intent) {
+        ChottuLink.getAppLinkData(intent).addOnSuccessListener { result ->
+            result?.link?.let { link ->
+                val code = link.getQueryParameter("code")
+                if (!code.isNullOrEmpty()) {
+                    inviteCode = code
                 }
             }
-        } }
+        }
+    }
 
 }

--- a/app/src/main/java/com/ddanddan/ddanddan/presentation/MainScreen.kt
+++ b/app/src/main/java/com/ddanddan/ddanddan/presentation/MainScreen.kt
@@ -60,7 +60,8 @@ import com.ddanddan.ui.ext.sharedViewModel
 fun MainScreen(
     navController: NavHostController = rememberNavController(),
     goToPlayStore: () -> Unit,
-    inviteCode: String? = null
+    inviteCode: String? = null,
+    onInviteCodeConsumed: () -> Unit = {}
 ) {
     val context = LocalContext.current
     val navBackStackEntry by navController.currentBackStackEntryAsState()
@@ -82,6 +83,7 @@ fun MainScreen(
                 popUpTo(navController.graph.id) { inclusive = false }
                 launchSingleTop = true
             }
+            onInviteCodeConsumed()
         }
     }
 

--- a/app/src/main/java/com/ddanddan/ddanddan/presentation/friends/FriendsScreen.kt
+++ b/app/src/main/java/com/ddanddan/ddanddan/presentation/friends/FriendsScreen.kt
@@ -204,8 +204,8 @@ fun FriendsScreen(
             isMyself = friendsState.myProfile?.id == friendsState.chosenUserDetail.id,
             showFireworks = friendsState.showFireworks,
             friendsState = friendsState,
-            isFromInvitation = friendsState.pendingInviteCode != null,  // 추가
-            onAddFriend = onAddFriend                                    // 추가
+            isFromInvitation = friendsState.pendingInviteCode != null,
+            onAddFriend = onAddFriend
         )
     }
 }

--- a/app/src/main/java/com/ddanddan/ddanddan/presentation/friends/ProfileDialog.kt
+++ b/app/src/main/java/com/ddanddan/ddanddan/presentation/friends/ProfileDialog.kt
@@ -273,7 +273,7 @@ fun ProfileDialog(
                 DDanMarginVerticalSpacer(20)
                 Button(
                     onClick = {
-                        if (!isFromInvitation) onClickCheers(userDetail.id)
+                        if (!isFromInvitation || userDetail.isFriend) onClickCheers(userDetail.id)
                         else onAddFriend(userDetail.id)
                     },
                     modifier = Modifier
@@ -287,7 +287,7 @@ fun ProfileDialog(
                     shape = RoundedCornerShape(4.dp)
                 ) {
                     Text(
-                        text = if (!isFromInvitation) "응원해요" else "친구하기",
+                        text = if (!isFromInvitation || userDetail.isFriend) "응원해요" else "친구하기",
                         style = DDanDDanTypo.current.HeadLine6,
                         color = DDanDDanColorPalette.current.color_text_button_primary_default
                     )

--- a/app/src/main/java/com/ddanddan/ddanddan/presentation/friends/ProfileDialog.kt
+++ b/app/src/main/java/com/ddanddan/ddanddan/presentation/friends/ProfileDialog.kt
@@ -269,7 +269,7 @@ fun ProfileDialog(
                     }
                 }
             }
-            if (!isMyself && (isFromInvitation || (userDetail.isFriend && friendsState?.isCheeredToday == false))) {
+            if (!isMyself && ((isFromInvitation && !userDetail.isFriend) || (userDetail.isFriend && friendsState?.isCheeredToday == false))) {
                 DDanMarginVerticalSpacer(20)
                 Button(
                     onClick = {


### PR DESCRIPTION
- close : #173 
- [x] 앱 이미 켜진 상태에서도 친구 추가 팝업
- [x] 이미 친구인 경우에 "친구하기" -> "응원하기"
- [x] 친구 코드로 여러 번 실행해도 팝업 띄우기 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved invite link handling: app now correctly processes invite codes when users open the app via invite links and navigates them to add the friend.

* **Bug Fixes**
  * Enhanced friend dialog logic to display appropriate actions based on context (add friend vs. cheer button behavior).

* **Refactor**
  * Restructured invite code management to be handled at the activity level for better state consistency across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->